### PR TITLE
Adds support for multipart email

### DIFF
--- a/lib/sendgrid_actionmailer_adapter/converters/contents.rb
+++ b/lib/sendgrid_actionmailer_adapter/converters/contents.rb
@@ -9,7 +9,13 @@ module SendGridActionMailerAdapter
       end
 
       def convert(mail)
-        ::SendGrid::Content.new(type: mail.mime_type, value: mail.body.to_s)
+        unless mail.body.multipart?
+          return ::SendGrid::Content.new(type: mail.mime_type, value: mail.body.to_s)
+        end
+
+        mail.body.parts.map do |part|
+          ::SendGrid::Content.new(type: part.mime_type, value: part.body.to_s)
+        end
       end
 
       def assign_attributes(sendgrid_mail, value)

--- a/lib/sendgrid_actionmailer_adapter/version.rb
+++ b/lib/sendgrid_actionmailer_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SendGridActionMailerAdapter
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/sendgrid_actionmailer_adapter/converters/contents_spec.rb
+++ b/spec/sendgrid_actionmailer_adapter/converters/contents_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe SendGridActionMailerAdapter::Converters::Contents do
     it { expect(subject.value).to eq(body) }
   end
 
+  context 'handling multipart mail' do
+    describe '#convert' do
+      subject { converter.convert(mail) }
+
+      let(:part) { ::Mail::Part.new(content_type: content_type, body: body) }
+      let(:content_type) { "#{type}; charset=UTF-8" }
+      let(:mail) do
+        ::Mail.new.tap { |m| 2.times { m.body << part } }
+      end
+
+      it { expect(subject).not_to be_empty }
+    end
+  end
+
   describe '#assign_attributes' do
     subject { converter.assign_attributes(sendgrid_mail, value) }
 


### PR DESCRIPTION
Currently when trying to send a multipart email an error occurs stating that we are trying to send an email with content of size 0 , because `mail.body.to_s` is empty on multipart emails.

this pull request changes the SendGridActionMailerAdapter::Converters::Contests in order to execute `sendgrid_mail.add_content` multiple times for each Mail::Part and increases the version.